### PR TITLE
Update User-Agent header

### DIFF
--- a/WePaySDK/WePayClient.cs
+++ b/WePaySDK/WePayClient.cs
@@ -16,7 +16,7 @@ namespace WePaySDK
             WebClient client = new WebClient();
             client.Headers.Add("Authorization", "Bearer " + accessToken);
             client.Headers.Add("Content-Type", "application/json");
-            client.Headers.Add("User-Agent", "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/21.0.1180.60 Safari/537.1");
+            client.Headers.Add("User-Agent", "WePay API C# SDK");
             var data = JsonConvert.SerializeObject(request);
             string uriString = WePayConfig.endpoint(WePayConfig.productionMode) + actionUrl;
             var json = "";


### PR DESCRIPTION
Update the User-Agent header to indicate that the HTTPS request is coming from the C# SDK. The current header makes it look like the request is coming from a browser. This is primarily of use on our end for debugging (we can look at an app's User-Agent to see which SDK, if any, they are using). 

Thanks for writing the SDK! We already have apps using it in production. 
