### PR TITLE
WePay API production endpoint fix

### DIFF
--- a/WePaySDK/Config.cs
+++ b/WePaySDK/Config.cs
@@ -19,7 +19,7 @@ namespace WePaySDK
         public static string authScope = "manage_accounts,view_balance,collect_payments,refund_payments,view_user,preapprove_payments,send_money";
         public static string endpoint(bool prod)
         {
-            if(prod) return @"https://www.wepayapi.com/v2/";
+            if(prod) return @"https://wepayapi.com/v2/";
             return @"https://stage.wepayapi.com/v2/";
         }
     }


### PR DESCRIPTION
The production endpoint was incorrectly pointing to
https://www.wepayapi.com/v2/, the correct endpoint is
https://wepayapi.com/v2/
